### PR TITLE
Do not set properties not found in the dictionary.

### DIFF
--- a/PDKTModelBuilder/PDKTEntityDataParser.m
+++ b/PDKTModelBuilder/PDKTEntityDataParser.m
@@ -78,7 +78,7 @@
 + (id)propertyValueForKey:(NSString *)key sourcePath:(NSString *)sourcePath inDictionary:(NSDictionary *)dictionary withTransformers:(NSDictionary *)propertiesTypeTransformers{
     id propertyValue;
     id rawValue = [dictionary valueForKeyPath:sourcePath];
-    if (![rawValue isKindOfClass:[NSNull class]]) {
+    if (rawValue && ![rawValue isKindOfClass:[NSNull class]]) {
         PDKTDataTransformer *entityProperty=[propertiesTypeTransformers valueForKey:key]?:[PDKTStringTransformer new];
         propertyValue=[entityProperty tranformValueFromObject:rawValue];
     }


### PR DESCRIPTION
In our application we had an entity which in some cases the JSON dictionary given by the server was missing some values. If a key in the dictionary is not found it shouldn't be setting the value of the entity.

Example:

Entity with nofitications_number property mapped to a value with the same key name in the dictionary, with an IntegerTransformer associated.
First JSON includes a notifications_number: 2
Entity.notifications_number = 2
Second JSON doesn't include a notifications_number and [dictionary valueForKeyPath:sourcePath] returns nil.
Entity.notifications_number = 0
When it doesn't make sense to translate a not found value.

Keep up the good work!
